### PR TITLE
docs - add `exposeProps` examples to readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -339,6 +339,112 @@ g.toJsx()
 g.toTsx()
 ```
 
+#### `exposeProps` - simple example
+
+Instead of instrumenting code by hand, especially for large models, you can `exposeProps` that map the component props to arbitrary `jsx` children.
+
+For example, if you want to be able to turn on/off shadows via `shadows: true` property, the following options:
+
+```ts
+  exposeProps: {
+    shadows: {
+      to: ['castShadow', 'receiveShadow'],
+      structure: {
+        type: 'boolean',
+        hasQuestionToken: true,
+      },
+    },
+  },
+```
+
+would generate code using `ts-morph` that will:
+
+- Add all mapped props to the `ModelProps` interface
+- Destructure variables in the function body with a ...rest
+- Change the identifer on the root <group {...rest} /> element
+- Set the argument in the function signature
+
+This roughly equates to this output:
+
+```tsx
+export interface FlightHelmetProps extends GroupProps {
+  shadows?: boolean
+}
+
+export function FlightHelmet(props: FlightHelmetProps) {
+  const { nodes, materials } = useGLTF(modelLoadPath, draco) as FlightHelmetGLTF
+  const { shadows, ...rest } = props
+
+  return (
+    <group {...rest} dispose={null}>
+      <mesh castShadow={shadows} receiveShadow={shadows} />
+    </group>
+  )
+}
+```
+
+NOTE: if the `Object3D` property does not exist as part of calculated properties, it cannot be known at generation time that it is safe to add. If you want to force it to be added, use a `matcher` (see next section).
+
+#### `exposeProps` - advanced example with `matcher`
+
+A more powerful option is using the match specific nodes and expose those properties. Observe the following pseudo types (truncated for simplicity, see source for full type information):
+
+```ts
+interface GenerateOptions {
+  /**
+   * Expose component prop and propagate to matching Object3D props
+   * e.g. shadows->[castShadow, receiveShadow]
+   */
+  exposeProps?: Record<string, MappedProp>
+}
+
+interface MappedProp {
+  /**
+   * Object3D prop(s)
+   * e.g. castShadow | [castShadow, receiveShadow]
+   * */
+  to: string | string[]
+  /**
+   * Match a specific type of object.
+   * If not provided, matches all that have the {to} prop
+   * */
+  matcher?: (o: Object3D, a: AnalyzedGLTF) => boolean
+  /**
+   * ts-morph prop structure (name is already supplied)
+   * */
+  structure: Omit<OptionalKind<PropertySignatureStructure>, 'name'>
+}
+```
+
+This allows flexible exposure on arbitrary elements specified by the `matcher`. For example, if I wanted to toggle visibility on/off for some named elements:
+
+```tsx
+for (const search of ['base', 'side', 'top']) {
+  options.exposeProps![search] = {
+    to: ['visible'],
+    structure: {
+      type: 'boolean',
+      hasQuestionToken: true,
+    },
+    matcher: (o, a) =>
+      // note isGroup doesn't work, because the model may be Object3D that is converted at generation time
+      (isMesh(o) || getJsxElementName(o, a) == 'group') && o.name?.toLowerCase().includes(search),
+  }
+}
+```
+
+this would map:
+
+```tsx
+export interface FooProps extends GroupProps {
+  base?: boolean
+  side?: boolean
+  top?: boolean
+}
+```
+
+to related elements. Because a `matcher` is specified, the property on the element will be added to every matching property.
+
 ## Requirements
 
 - Nodejs >= 16 must be installed

--- a/src/options.ts
+++ b/src/options.ts
@@ -53,7 +53,7 @@ export interface AnalyzedGLTFOptions extends PropsOptions {
   precision: number
 }
 
-export type MappedProp = {
+export interface MappedProp {
   /**
    * Object3D prop(s)
    * e.g. castShadow | [castShadow, receiveShadow]

--- a/src/r3f/GenerateR3F.ts
+++ b/src/r3f/GenerateR3F.ts
@@ -176,10 +176,10 @@ export class GenerateR3F<O extends GenerateOptions = GenerateOptions> extends Ab
   }
 
   /**
-   * - add all mapped props to the ModelProps interface
-   * - destructure variables in the function body with a ...rest
-   * - change the identifer on the <group {...rest} /> element
-   * - set the argument in the function signature
+   * - Add all mapped props to the ModelProps interface
+   * - Destructure variables in the function body with a ...rest
+   * - Change the identifer on the root <group {...rest} /> element
+   * - Set the argument in the function signature
    */
   protected exposeProps() {
     if (this.exposedPropsEncountered.size === 0) return


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>7.0.4--canary.5.f64a6e2.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @rosskevin/gltfjsx@7.0.4--canary.5.f64a6e2.0
  # or 
  yarn add @rosskevin/gltfjsx@7.0.4--canary.5.f64a6e2.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
