### PR TITLE
exposeProps should provide for overwriting as well as fallback for optional props

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -67,6 +67,8 @@ export interface AnalyzedGLTFOptions extends PropsOptions {
 
 export type Matcher = (o: Object3D, a: AnalyzedGLTF) => boolean
 
+export type ExposePropStructure = Omit<OptionalKind<PropertySignatureStructure>, 'name'>
+
 export interface ExposedProp {
   /**
    * Object3D prop(s)
@@ -81,7 +83,7 @@ export interface ExposedProp {
   /**
    * ts-morph prop structure (name is already supplied)
    * */
-  structure: Omit<OptionalKind<PropertySignatureStructure>, 'name'>
+  structure: ExposePropStructure
 }
 
 export interface GenerateOptions extends PropsOptions {

--- a/src/options.ts
+++ b/src/options.ts
@@ -81,7 +81,12 @@ export interface ExposedProp {
    * */
   matcher?: Matcher
   /**
-   * ts-morph prop structure (name is already supplied)
+   * ts-morph prop type structure (name is already supplied)
+   * e.g.
+   *    structure: {
+   *      type: 'boolean',
+   *      hasQuestionToken: true,
+   *    },
    * */
   structure: ExposePropStructure
 }

--- a/src/options.ts
+++ b/src/options.ts
@@ -67,7 +67,7 @@ export interface AnalyzedGLTFOptions extends PropsOptions {
 
 export type Matcher = (o: Object3D, a: AnalyzedGLTF) => boolean
 
-export interface MappedProp {
+export interface ExposedProp {
   /**
    * Object3D prop(s)
    * e.g. castShadow | [castShadow, receiveShadow]
@@ -106,7 +106,7 @@ export interface GenerateOptions extends PropsOptions {
    * Expose component prop and propagate to matching Object3D props
    * e.g. shadows->[castShadow, receiveShadow]
    */
-  exposeProps?: Record<string, MappedProp>
+  exposeProps?: Record<string, ExposedProp>
   /**
    * Load path for the model for useGLTF()
    */

--- a/src/r3f/GenerateR3F.ts
+++ b/src/r3f/GenerateR3F.ts
@@ -218,22 +218,22 @@ export class GenerateR3F<O extends GenerateOptions = GenerateOptions> extends Ab
   }
 
   /**
-   * Iterate over all exposeProps and return the component prop name if it matches.
+   * Iterate over all exposeProps and return the component prop name if it explicitly matches.
    * @param o
    * @param to the Object3D property name
    * @returns the component prop name if it matches
    */
-  protected getMappedComponentProp(
+  protected getExposedComponentProp(
     o: Object3D,
     to: string,
   ): keyof GenerateOptions['exposeProps'] | undefined {
     const { exposeProps } = this.options
     if (!exposeProps) return
 
-    for (const [componentProp, mappedProp] of Object.entries(exposeProps)) {
+    for (const [componentProp, exposeProp] of Object.entries(exposeProps)) {
       if (
-        mappedProp.to.includes(to) &&
-        (mappedProp.matcher === undefined || mappedProp?.matcher(o, this.a))
+        exposeProp.to.includes(to) &&
+        (exposeProp.matcher === undefined || exposeProp?.matcher(o, this.a))
       ) {
         return componentProp as keyof GenerateOptions['exposeProps']
       }
@@ -253,7 +253,7 @@ export class GenerateR3F<O extends GenerateOptions = GenerateOptions> extends Ab
       .map((key: string) => {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         let value = props[key]
-        const componentProp = this.getMappedComponentProp(o, key)
+        const componentProp = this.getExposedComponentProp(o, key)
         if (componentProp) {
           log.debug(
             `Propagating ${key}={${componentProp}} on <${getJsxElementName(o, this.a)} name='${o.name}'/>`,

--- a/src/r3f/GenerateR3F.ts
+++ b/src/r3f/GenerateR3F.ts
@@ -364,7 +364,7 @@ export class GenerateR3F<O extends GenerateOptions = GenerateOptions> extends Ab
       import { useAnimations, useGLTF, Merged, PerspectiveCamera, OrthographicCamera } from '@react-three/drei'
       import { GroupProps, MeshProps, useGraph } from '@react-three/fiber'
       import * as React from 'react'
-      import { AnimationClip, Mesh, MeshPhysicalMaterial, MeshStandardMaterial } from 'three'
+      import { AnimationClip, Material, Mesh, MeshPhysicalMaterial, MeshStandardMaterial } from 'three'
       import { GLTF, SkeletonUtils } from 'three-stdlib'
 
       ${

--- a/src/r3f/GenerateR3F.ts
+++ b/src/r3f/GenerateR3F.ts
@@ -263,10 +263,12 @@ export class GenerateR3F<O extends GenerateOptions = GenerateOptions> extends Ab
         const exposed = this.getExposedComponentProp(o, key)
         if (exposed) {
           const { componentProp, structure } = exposed
-          // if component prop is optional, ensure the fallback to the original model
+          // if component prop is optional, is not boolean, and is not currently undefined, allow fallback to the original model value
           if (
-            structure.hasQuestionToken == true ||
-            (typeof structure.type === 'string' && structure.type.includes('undefined'))
+            value !== undefined &&
+            structure.type !== 'boolean' &&
+            (structure.hasQuestionToken == true ||
+              (typeof structure.type === 'string' && structure.type.includes('undefined')))
           ) {
             value = `${componentProp} || ${value}`
           } else {
@@ -274,11 +276,10 @@ export class GenerateR3F<O extends GenerateOptions = GenerateOptions> extends Ab
             value = componentProp
           }
           log.debug(
-            `Propagating ${key}={${componentProp}} on <${getJsxElementName(o, this.a)} name='${o.name}'/>`,
+            `Propagating ${key}={${value}} on <${getJsxElementName(o, this.a)} name='${o.name}'/>`,
           )
           this.exposedPropsEncountered.add(componentProp)
         }
-
         if (stringProps.includes(key)) {
           return `${key}="${value}"`
         }
@@ -316,8 +317,9 @@ export class GenerateR3F<O extends GenerateOptions = GenerateOptions> extends Ab
           }
           for (const to of toArray) {
             log.debug(`Forcing propagation of ${to}={${componentProp}} name='${o.name}'`)
-            // fabricate a value to be remapped
-            props[to] = 'foobarbaz'
+            // Use an existing value (for potential fallback), or fabricate a value to be remapped
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+            props[to] = props[to] || undefined
           }
         }
       }

--- a/test/r3f/GenerateR3F.test.ts
+++ b/test/r3f/GenerateR3F.test.ts
@@ -6,7 +6,6 @@ import {
   AnalyzedGLTF,
   GenerateOptions,
   GenerateR3F,
-  isMesh,
   loadGLTF,
   resolveModelLoadPath,
 } from '../../src/index.js'
@@ -23,7 +22,6 @@ describe('GenerateR3F', () => {
   describe(modelName, () => {
     for (const type of types) {
       const modelFile = resolveFixtureModelFile(modelName, type)
-
       describe(type, () => {
         let model: GLTF
         let options: GenerateOptions
@@ -91,137 +89,6 @@ describe('GenerateR3F', () => {
               expect(code.match(/receiveShadow/g)?.length).toEqual(6)
             }
           }
-        })
-
-        describe('exposeProps', () => {
-          it.concurrent('should generate to[]', async () => {
-            const mo: GenerateOptions = {
-              ...options,
-              exposeProps: {
-                shadows: {
-                  to: ['castShadow', 'receiveShadow'],
-                  structure: {
-                    type: 'boolean',
-                    hasQuestionToken: true,
-                  },
-                },
-              },
-            }
-            const g = new GenerateR3F(a, mo)
-            assertCommon(g)
-            const tsx = await g.toTsx()
-            console.log(tsx)
-            const jsx = await g.toJsx()
-
-            for (const code of [tsx, jsx]) {
-              if (type.includes('instanceall')) {
-                assertInstanceAllCommon(code)
-                expect(code.match(/<instances/g)?.length).toEqual(6)
-                expect(code.match(/.*receiveShadow=\{shadows\}/g)?.length).toEqual(6)
-                expect(code.match(/.*castShadow=\{shadows\}/g)?.length).toEqual(6)
-              } else {
-                expect(code.match(/castShadow=\{shadows\}/g)?.length).toEqual(6)
-                expect(code.match(/receiveShadow=\{shadows\}/g)?.length).toEqual(6)
-              }
-            }
-          })
-
-          it.concurrent('should generate to (singular)', async () => {
-            const mo: GenerateOptions = {
-              ...options,
-              exposeProps: {
-                shadows: {
-                  to: 'castShadow',
-                  structure: {
-                    type: 'boolean',
-                    hasQuestionToken: true,
-                  },
-                },
-              },
-            }
-            const g = new GenerateR3F(a, mo)
-            assertCommon(g)
-            const tsx = await g.toTsx()
-            console.log(tsx)
-            const jsx = await g.toJsx()
-
-            for (const code of [tsx, jsx]) {
-              if (type.includes('instanceall')) {
-                assertInstanceAllCommon(code)
-                expect(code.match(/<instances\..*castShadow=\{shadows\}/g)?.length).toEqual(6)
-                expect(code.match(/<instances\..*receiveShadow /g)?.length).toEqual(6)
-              } else {
-                expect(code.match(/castShadow=\{shadows\}/g)?.length).toEqual(6)
-                expect(code.match(/receiveShadow\n/g)?.length).toEqual(6)
-              }
-            }
-          })
-
-          describe('matcher', () => {
-            it.concurrent('should limit matches', async () => {
-              const mo: GenerateOptions = {
-                ...options,
-                exposeProps: {
-                  shadows: {
-                    to: 'castShadow',
-                    structure: {
-                      type: 'boolean',
-                      hasQuestionToken: true,
-                    },
-                    matcher: (o) => isMesh(o) && o.name === 'GlassPlastic_low',
-                  },
-                },
-              }
-              const g = new GenerateR3F(a, mo)
-              assertCommon(g)
-              const tsx = await g.toTsx()
-              console.log(tsx)
-              const jsx = await g.toJsx()
-
-              for (const code of [tsx, jsx]) {
-                if (type.includes('instanceall')) {
-                  assertInstanceAllCommon(code)
-                  expect(code.match(/<instances\..*castShadow=\{shadows\}/g)?.length).toEqual(1)
-                  expect(code.match(/<instances\..*receiveShadow /g)?.length).toEqual(6)
-                } else {
-                  expect(code.match(/castShadow=\{shadows\}/g)?.length).toEqual(1)
-                  expect(code.match(/receiveShadow\n/g)?.length).toEqual(6)
-                }
-              }
-            })
-
-            // e.g. visible - it may not be present in calculated (because it defaults to true),
-            // but we need to be sure we add it to a matched case to ensure propagation
-            it.concurrent('should propagate non-calculated property', async () => {
-              const mo: GenerateOptions = {
-                ...options,
-                exposeProps: {
-                  hoseVisible: {
-                    to: 'visible',
-                    structure: {
-                      type: 'boolean',
-                      hasQuestionToken: true,
-                    },
-                    matcher: (o) => isMesh(o) && o.name === 'Hose_low',
-                  },
-                },
-              }
-              const g = new GenerateR3F(a, mo)
-              assertCommon(g)
-              const tsx = await g.toTsx()
-              console.log(tsx)
-              const jsx = await g.toJsx()
-
-              for (const code of [tsx, jsx]) {
-                if (type.includes('instanceall')) {
-                  assertInstanceAllCommon(code)
-                  expect(code.match(/<instances\..*visible=\{hoseVisible\}/g)?.length).toEqual(1)
-                } else {
-                  expect(code.match(/visible=\{hoseVisible\}/g)?.length).toEqual(1)
-                }
-              }
-            })
-          })
         })
       })
     }

--- a/test/r3f/GenerateR3F.test.ts
+++ b/test/r3f/GenerateR3F.test.ts
@@ -1,6 +1,6 @@
 import { DRACOLoader, GLTF } from 'node-three-gltf'
 import { SyntaxKind } from 'ts-morph'
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
 import {
   AnalyzedGLTF,
@@ -28,14 +28,8 @@ describe('GenerateR3F', () => {
         let a: AnalyzedGLTF
         let dracoLoader: DRACOLoader
 
-        beforeAll(() => {
+        beforeAll(async () => {
           dracoLoader = new DRACOLoader()
-        })
-        afterAll(() => {
-          dracoLoader.dispose()
-        })
-
-        beforeEach(async () => {
           assertFileExists(modelFile)
           model = await loadGLTF(modelFile, dracoLoader)
           options = fixtureGenerateOptions({
@@ -50,6 +44,12 @@ describe('GenerateR3F', () => {
           })
           a = new AnalyzedGLTF(model, fixtureAnalyzeOptions(options))
         })
+        afterAll(() => {
+          dracoLoader.dispose()
+        })
+
+        // beforeEach(async () => {
+        // })
 
         function assertCommon(g: GenerateR3F) {
           expect(g.project).not.toBeNull()

--- a/test/r3f/exposeProps.test.ts
+++ b/test/r3f/exposeProps.test.ts
@@ -53,35 +53,39 @@ describe('exposeProps', () => {
         // })
 
         describe('no matcher', () => {
-          it.concurrent('should generate to[]', async () => {
-            const mo: GenerateOptions = {
-              ...options,
-              exposeProps: {
-                shadows: {
-                  to: ['castShadow', 'receiveShadow'],
-                  structure: {
-                    type: 'boolean',
-                    hasQuestionToken: true,
+          it.concurrent(
+            'should generate to[]',
+            async () => {
+              const mo: GenerateOptions = {
+                ...options,
+                exposeProps: {
+                  shadows: {
+                    to: ['castShadow', 'receiveShadow'],
+                    structure: {
+                      type: 'boolean',
+                      hasQuestionToken: true,
+                    },
                   },
                 },
-              },
-            }
-            const g = new GenerateR3F(a, mo)
-            const tsx = await g.toTsx()
-            console.log(tsx)
-            const jsx = await g.toJsx()
-
-            for (const code of [tsx, jsx]) {
-              if (type.includes('instanceall')) {
-                expect(code.match(/<instances/g)?.length).toEqual(6)
-                expect(code.match(/.*receiveShadow=\{shadows\}/g)?.length).toEqual(6)
-                expect(code.match(/.*castShadow=\{shadows\}/g)?.length).toEqual(6)
-              } else {
-                expect(code.match(/castShadow=\{shadows\}/g)?.length).toEqual(6)
-                expect(code.match(/receiveShadow=\{shadows\}/g)?.length).toEqual(6)
               }
-            }
-          })
+              const g = new GenerateR3F(a, mo)
+              const tsx = await g.toTsx()
+              console.log(tsx)
+              const jsx = await g.toJsx()
+
+              for (const code of [tsx, jsx]) {
+                if (type.includes('instanceall')) {
+                  expect(code.match(/<instances/g)?.length).toEqual(6)
+                  expect(code.match(/.*receiveShadow=\{shadows\}/g)?.length).toEqual(6)
+                  expect(code.match(/.*castShadow=\{shadows\}/g)?.length).toEqual(6)
+                } else {
+                  expect(code.match(/castShadow=\{shadows\}/g)?.length).toEqual(6)
+                  expect(code.match(/receiveShadow=\{shadows\}/g)?.length).toEqual(6)
+                }
+              }
+            },
+            10000, // increase timeout for ci - typical timeout if 5000ms
+          )
 
           it.concurrent('should generate to (singular)', async () => {
             const mo: GenerateOptions = {

--- a/test/r3f/exposeProps.test.ts
+++ b/test/r3f/exposeProps.test.ts
@@ -1,0 +1,275 @@
+import { DRACOLoader, GLTF } from 'node-three-gltf'
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  AnalyzedGLTF,
+  GenerateOptions,
+  GenerateR3F,
+  isMesh,
+  loadGLTF,
+  resolveModelLoadPath,
+} from '../../src/index.js'
+import {
+  assertFileExists,
+  fixtureAnalyzeOptions,
+  fixtureGenerateOptions,
+  resolveFixtureModelFile,
+  types,
+} from '../fixtures.js'
+
+const modelName = 'FlightHelmet'
+describe('exposeProps', () => {
+  describe(modelName, () => {
+    for (const type of types) {
+      const modelFile = resolveFixtureModelFile(modelName, type)
+
+      describe(type, () => {
+        let model: GLTF
+        let options: GenerateOptions
+        let a: AnalyzedGLTF
+        let dracoLoader: DRACOLoader
+
+        beforeAll(() => {
+          dracoLoader = new DRACOLoader()
+        })
+        afterAll(() => {
+          dracoLoader.dispose()
+        })
+
+        beforeEach(async () => {
+          assertFileExists(modelFile)
+          model = await loadGLTF(modelFile, dracoLoader)
+          options = fixtureGenerateOptions({
+            componentName: modelName,
+            draco: type.includes('draco'),
+            header: 'FOO header',
+            modelLoadPath: resolveModelLoadPath(modelFile, '/public/models'),
+            // types: true,
+            keepnames: true,
+            shadows: true,
+            instanceall: type.includes('instanceall'),
+          })
+          a = new AnalyzedGLTF(model, fixtureAnalyzeOptions(options))
+        })
+
+        describe('no matcher', () => {
+          it('should generate to[]', async () => {
+            const mo: GenerateOptions = {
+              ...options,
+              exposeProps: {
+                shadows: {
+                  to: ['castShadow', 'receiveShadow'],
+                  structure: {
+                    type: 'boolean',
+                    hasQuestionToken: true,
+                  },
+                },
+              },
+            }
+            const g = new GenerateR3F(a, mo)
+            const tsx = await g.toTsx()
+            console.log(tsx)
+            const jsx = await g.toJsx()
+
+            for (const code of [tsx, jsx]) {
+              if (type.includes('instanceall')) {
+                expect(code.match(/<instances/g)?.length).toEqual(6)
+                expect(code.match(/.*receiveShadow=\{shadows\}/g)?.length).toEqual(6)
+                expect(code.match(/.*castShadow=\{shadows\}/g)?.length).toEqual(6)
+              } else {
+                expect(code.match(/castShadow=\{shadows\}/g)?.length).toEqual(6)
+                expect(code.match(/receiveShadow=\{shadows\}/g)?.length).toEqual(6)
+              }
+            }
+          })
+
+          it('should generate to (singular)', async () => {
+            const mo: GenerateOptions = {
+              ...options,
+              exposeProps: {
+                shadows: {
+                  to: 'castShadow',
+                  structure: {
+                    type: 'boolean',
+                    hasQuestionToken: true,
+                  },
+                },
+              },
+            }
+            const g = new GenerateR3F(a, mo)
+            const tsx = await g.toTsx()
+            console.log(tsx)
+            const jsx = await g.toJsx()
+
+            for (const code of [tsx, jsx]) {
+              if (type.includes('instanceall')) {
+                expect(code.match(/<instances\..*castShadow=\{shadows\}/g)?.length).toEqual(6)
+                expect(code.match(/<instances\..*receiveShadow /g)?.length).toEqual(6)
+              } else {
+                expect(code.match(/castShadow=\{shadows\}/g)?.length).toEqual(6)
+                expect(code.match(/receiveShadow\n/g)?.length).toEqual(6)
+              }
+            }
+          })
+        })
+
+        describe('matcher', () => {
+          it('should limit matches', async () => {
+            const mo: GenerateOptions = {
+              ...options,
+              exposeProps: {
+                shadows: {
+                  to: 'castShadow',
+                  structure: {
+                    type: 'boolean',
+                    hasQuestionToken: true,
+                  },
+                  matcher: (o) => isMesh(o) && o.name === 'GlassPlastic_low',
+                },
+              },
+            }
+            const g = new GenerateR3F(a, mo)
+            const tsx = await g.toTsx()
+            console.log(tsx)
+            const jsx = await g.toJsx()
+
+            for (const code of [tsx, jsx]) {
+              if (type.includes('instanceall')) {
+                expect(code.match(/<instances\.Hose_low.*castShadow=\{shadows\}/g)?.length).toEqual(
+                  1,
+                )
+                expect(code.match(/<instances\.Hose_low.*receiveShadow /g)?.length).toEqual(6)
+              } else {
+                expect(code.match(/castShadow=\{shadows\}/g)?.length).toEqual(1)
+                expect(code.match(/receiveShadow\n/g)?.length).toEqual(6)
+              }
+            }
+          })
+
+          describe('non-existing (non-calculated)', () => {
+            // e.g. visible - it may not be present in calculated (because it defaults to true),
+            // but we need to be sure we add it to a matched case to ensure propagation
+            it('should propagate property', async () => {
+              const mo: GenerateOptions = {
+                ...options,
+                exposeProps: {
+                  hoseVisible: {
+                    to: 'visible',
+                    structure: {
+                      type: 'boolean',
+                      hasQuestionToken: true,
+                    },
+                    matcher: (o) => isMesh(o) && o.name === 'Hose_low',
+                  },
+                },
+              }
+              const g = new GenerateR3F(a, mo)
+              const tsx = await g.toTsx()
+              console.log(tsx)
+              const jsx = await g.toJsx()
+
+              for (const code of [tsx, jsx]) {
+                if (type.includes('instanceall')) {
+                  expect(
+                    code.match(/<instances\.Hose_low.*visible=\{hoseVisible\}/g)?.length,
+                  ).toEqual(1)
+                } else {
+                  expect(code.match(/visible=\{hoseVisible\}/g)?.length).toEqual(1)
+                }
+              }
+            })
+          })
+
+          describe('pre-existing (calculated)', () => {
+            // provided prop is not `undefined` type or `hasQuestionToken: true`
+            it('should overwrite required property', async () => {
+              const mo: GenerateOptions = {
+                ...options,
+                exposeProps: {
+                  hoseMaterial: {
+                    to: 'material',
+                    structure: {
+                      type: 'Material',
+                    },
+                    matcher: (o) => isMesh(o) && o.name === 'Hose_low',
+                  },
+                },
+              }
+              const g = new GenerateR3F(a, mo)
+              const tsx = await g.toTsx()
+              console.log(tsx)
+              const jsx = await g.toJsx()
+
+              for (const code of [tsx, jsx]) {
+                if (type.includes('instanceall')) {
+                  expect(
+                    code.match(/<instances\.Hose_low.*material=\{hoseMaterial\}/g)?.length,
+                  ).toEqual(1)
+                } else {
+                  expect(code.match(/material=\{hoseMaterial\}/g)?.length).toEqual(1)
+                }
+              }
+            })
+
+            describe('optional fallback', () => {
+              async function assertFallback(g: GenerateR3F) {
+                const tsx = await g.toTsx()
+                console.log(tsx)
+                const jsx = await g.toJsx()
+
+                for (const code of [tsx, jsx]) {
+                  if (type.includes('instanceall')) {
+                    expect(
+                      code.match(
+                        /<instances\.Hose_low.*visible=\{hoseVisible || materials.HoseMat\}/g,
+                      )?.length,
+                    ).toEqual(1)
+                  } else {
+                    expect(
+                      code.match(/visible=\{hoseVisible || materials.HoseMat\}/g)?.length,
+                    ).toEqual(1)
+                  }
+                }
+              }
+
+              it('should override property with hasQuestionToken', async () => {
+                const mo: GenerateOptions = {
+                  ...options,
+                  exposeProps: {
+                    hoseMaterial: {
+                      to: 'material',
+                      structure: {
+                        type: 'Material',
+                        hasQuestionToken: true,
+                      },
+                      matcher: (o) => isMesh(o) && o.name === 'Hose_low',
+                    },
+                  },
+                }
+                const g = new GenerateR3F(a, mo)
+                await assertFallback(g)
+              })
+
+              it('should override property with type contains undefined', async () => {
+                const mo: GenerateOptions = {
+                  ...options,
+                  exposeProps: {
+                    hoseMaterial: {
+                      to: 'material',
+                      structure: {
+                        type: 'Material | undefined',
+                      },
+                      matcher: (o) => isMesh(o) && o.name === 'Hose_low',
+                    },
+                  },
+                }
+                const g = new GenerateR3F(a, mo)
+                await assertFallback(g)
+              })
+            })
+          })
+        })
+      })
+    }
+  })
+})

--- a/test/r3f/exposeProps.test.ts
+++ b/test/r3f/exposeProps.test.ts
@@ -1,5 +1,5 @@
 import { DRACOLoader, GLTF } from 'node-three-gltf'
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
 import {
   AnalyzedGLTF,
@@ -29,14 +29,8 @@ describe('exposeProps', () => {
         let a: AnalyzedGLTF
         let dracoLoader: DRACOLoader
 
-        beforeAll(() => {
+        beforeAll(async () => {
           dracoLoader = new DRACOLoader()
-        })
-        afterAll(() => {
-          dracoLoader.dispose()
-        })
-
-        beforeEach(async () => {
           assertFileExists(modelFile)
           model = await loadGLTF(modelFile, dracoLoader)
           options = fixtureGenerateOptions({
@@ -51,6 +45,12 @@ describe('exposeProps', () => {
           })
           a = new AnalyzedGLTF(model, fixtureAnalyzeOptions(options))
         })
+        afterAll(() => {
+          dracoLoader.dispose()
+        })
+
+        // beforeEach(async () => {
+        // })
 
         describe('no matcher', () => {
           it.concurrent('should generate to[]', async () => {

--- a/test/r3f/exposeProps.test.ts
+++ b/test/r3f/exposeProps.test.ts
@@ -53,7 +53,7 @@ describe('exposeProps', () => {
         })
 
         describe('no matcher', () => {
-          it('should generate to[]', async () => {
+          it.concurrent('should generate to[]', async () => {
             const mo: GenerateOptions = {
               ...options,
               exposeProps: {
@@ -83,7 +83,7 @@ describe('exposeProps', () => {
             }
           })
 
-          it('should generate to (singular)', async () => {
+          it.concurrent('should generate to (singular)', async () => {
             const mo: GenerateOptions = {
               ...options,
               exposeProps: {
@@ -114,7 +114,7 @@ describe('exposeProps', () => {
         })
 
         describe('matcher', () => {
-          it('should limit matches', async () => {
+          it.concurrent('should limit matches', async () => {
             const mo: GenerateOptions = {
               ...options,
               exposeProps: {
@@ -135,10 +135,12 @@ describe('exposeProps', () => {
 
             for (const code of [tsx, jsx]) {
               if (type.includes('instanceall')) {
-                expect(code.match(/<instances\.Hose_low.*castShadow=\{shadows\}/g)?.length).toEqual(
+                expect(
+                  code.match(/<instances\.GlassPlastic_low.*castShadow=\{shadows\}/g)?.length,
+                ).toEqual(1)
+                expect(code.match(/<instances\.GlassPlastic_low.*receiveShadow /g)?.length).toEqual(
                   1,
                 )
-                expect(code.match(/<instances\.Hose_low.*receiveShadow /g)?.length).toEqual(6)
               } else {
                 expect(code.match(/castShadow=\{shadows\}/g)?.length).toEqual(1)
                 expect(code.match(/receiveShadow\n/g)?.length).toEqual(6)
@@ -149,7 +151,7 @@ describe('exposeProps', () => {
           describe('non-existing (non-calculated)', () => {
             // e.g. visible - it may not be present in calculated (because it defaults to true),
             // but we need to be sure we add it to a matched case to ensure propagation
-            it('should propagate property', async () => {
+            it.concurrent('should propagate property', async () => {
               const mo: GenerateOptions = {
                 ...options,
                 exposeProps: {
@@ -182,7 +184,7 @@ describe('exposeProps', () => {
 
           describe('pre-existing (calculated)', () => {
             // provided prop is not `undefined` type or `hasQuestionToken: true`
-            it('should overwrite required property', async () => {
+            it.concurrent('should overwrite required property', async () => {
               const mo: GenerateOptions = {
                 ...options,
                 exposeProps: {
@@ -220,19 +222,17 @@ describe('exposeProps', () => {
                 for (const code of [tsx, jsx]) {
                   if (type.includes('instanceall')) {
                     expect(
-                      code.match(
-                        /<instances\.Hose_low.*visible=\{hoseVisible || materials.HoseMat\}/g,
-                      )?.length,
+                      code.match(/<instances\.Hose_low.*material=\{hoseMaterial\}/g)?.length,
                     ).toEqual(1)
                   } else {
                     expect(
-                      code.match(/visible=\{hoseVisible \|\| materials.HoseMat\}/g)?.length,
+                      code.match(/material=\{hoseMaterial \|\| materials.HoseMat\}/g)?.length,
                     ).toEqual(1)
                   }
                 }
               }
 
-              it('should override property with hasQuestionToken', async () => {
+              it.concurrent('should override property with hasQuestionToken', async () => {
                 const mo: GenerateOptions = {
                   ...options,
                   exposeProps: {
@@ -250,7 +250,7 @@ describe('exposeProps', () => {
                 await assertFallback(g)
               })
 
-              it('should override property with type contains undefined', async () => {
+              it.concurrent('should override property with type contains undefined', async () => {
                 const mo: GenerateOptions = {
                   ...options,
                   exposeProps: {

--- a/test/r3f/exposeProps.test.ts
+++ b/test/r3f/exposeProps.test.ts
@@ -226,7 +226,7 @@ describe('exposeProps', () => {
                     ).toEqual(1)
                   } else {
                     expect(
-                      code.match(/visible=\{hoseVisible || materials.HoseMat\}/g)?.length,
+                      code.match(/visible=\{hoseVisible \|\| materials.HoseMat\}/g)?.length,
                     ).toEqual(1)
                   }
                 }


### PR DESCRIPTION
If component prop is optional, is not boolean, and is not currently undefined, allow fallback to the original model value.

Booleans don't fall back because it's cruft, like `visible || true`

closes #6 

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>7.0.23--canary.7.a08eaa4.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @rosskevin/gltfjsx@7.0.23--canary.7.a08eaa4.0
  # or 
  yarn add @rosskevin/gltfjsx@7.0.23--canary.7.a08eaa4.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
