### PR TITLE
Add helper for exposeProps api reuse isMatchIncludingAncestors

### DIFF
--- a/src/analyze/is.ts
+++ b/src/analyze/is.ts
@@ -18,6 +18,9 @@ import {
   SpotLight,
 } from 'three'
 
+import { Matcher } from '../options.js'
+import { AnalyzedGLTF } from './AnalyzedGLTF.js'
+
 export type isFn = (o: any) => boolean
 
 export const isObject3D = (o: any): o is Object3D => (o as any).isObject3D
@@ -82,17 +85,24 @@ export const setRemoved = (o: any, value = true): void => {
   o.__removed = value
 }
 
-// export const isNotRemovedIncludingAncestors = (o: Object3D): boolean => {
-//   if (isRemoved(o)) return false
+/**
+ * Helper for external matchers to determine if node is of interest e.g. `exposeProps`
+ */
+export const isMatchIncludingAncestors = (
+  o: Object3D,
+  a: AnalyzedGLTF,
+  matcher: Matcher,
+): boolean => {
+  if (matcher(o, a)) return true
 
-//   let ancestor = o.parent
-//   while (ancestor) {
-//     if (isRemoved(ancestor)) return false
-//     ancestor = ancestor.parent
-//   }
+  let ancestor = o.parent
+  while (ancestor) {
+    if (matcher(ancestor, a)) return true
+    ancestor = ancestor.parent
+  }
 
-//   return true
-// }
+  return false
+}
 
 interface Colored {
   color: Color


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>7.1.2--canary.8.0b06427.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @rosskevin/gltfjsx@7.1.2--canary.8.0b06427.0
  # or 
  yarn add @rosskevin/gltfjsx@7.1.2--canary.8.0b06427.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
