### PR TITLE
fix: fiber-v9 / drei-v10 / React-19 compatible R3F component output (#17)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 `@rosskevin/gltfjsx` — a CLI + library that converts GLTF/GLB 3D models into React Three Fiber (R3F) component source (`.tsx`/`.jsx`). Published to npm as an ESM-only package; the `bin` is `dist/cli.mjs`. It is a (intended-to-be-temporary) fork of [`pmndrs/gltfjsx`](https://github.com/pmndrs/gltfjsx) — see `README.md`. PRs are expected to include tests.
 
+**GitHub CLI:** no `gh` default repo is set here, so with both `origin` (the fork) and `upstream` (`pmndrs/gltfjsx`) remotes, bare `gh` commands resolve to the upstream parent — e.g. `gh issue view 17` shows the wrong (upstream) issue. Pass `-R rosskevin/gltfjsx` for this fork's issues/PRs (`gh issue view 17 -R rosskevin/gltfjsx`), or set it once with `gh repo set-default rosskevin/gltfjsx`.
+
 ## Commands
 
 - `pnpm build` — bundle with tsdown → `dist/*.mjs` + `.d.mts` (the CLI shebang and executable bit are handled automatically).

--- a/src/generate/r3f/GenerateR3F.ts
+++ b/src/generate/r3f/GenerateR3F.ts
@@ -346,6 +346,10 @@ export class GenerateR3F<O extends GenerateOptions = GenerateOptions> extends Ab
     return `${this.options.componentName}Props`
   }
 
+  protected getModelPropsBaseName() {
+    return `${this.options.componentName}PropsBase`
+  }
+
   protected getModelActionName() {
     return `${this.options.componentName}Action`
   }
@@ -394,9 +398,9 @@ export class GenerateR3F<O extends GenerateOptions = GenerateOptions> extends Ab
           : ''
       }
       import { useAnimations, useGLTF, Merged, PerspectiveCamera, OrthographicCamera } from '@react-three/drei'
-      import { GroupProps, MeshProps, useGraph } from '@react-three/fiber'
+      import { type ThreeElements, useGraph } from '@react-three/fiber'
       import * as React from 'react'
-      import { AnimationClip, Material, Mesh, MeshPhysicalMaterial, MeshStandardMaterial } from 'three'
+      import { AnimationClip, Group, Material, Mesh, MeshPhysicalMaterial, MeshStandardMaterial } from 'three'
       import { GLTF, SkeletonUtils } from 'three-stdlib'
 
       ${
@@ -414,7 +418,9 @@ export class GenerateR3F<O extends GenerateOptions = GenerateOptions> extends Ab
         ${hasAnimations ? `animations: ${modelActionName}[]` : ''}
       }
 
-      export interface ${modelPropsName} extends GroupProps {}
+      type ${this.getModelPropsBaseName()} = ThreeElements['group']
+
+      export interface ${modelPropsName} extends ${this.getModelPropsBaseName()} {}
 
       const modelLoadPath = '<foo>.glb'
       const draco = false
@@ -422,12 +428,12 @@ export class GenerateR3F<O extends GenerateOptions = GenerateOptions> extends Ab
       ${
         hasInstances
           ? `
-      type ContextType = Record<string, React.ForwardRefExoticComponent<MeshProps>>
+      type ContextType = Record<string, React.ForwardRefExoticComponent<ThreeElements['mesh']>>
 
       const context = React.createContext<ContextType>({})
 
       export ${exportdefault ? 'default' : ''} function ${modelInstancesName}({ children, ...props }: ${modelPropsName}) {
-        const { nodes } = useGLTF(modelLoadPath, draco) as ${modelGLTFName}
+        const { nodes } = useGLTF(modelLoadPath, draco) as unknown as ${modelGLTFName}
         const instances = React.useMemo(() => ({
           ${dupGeometryValues.map((v) => `${v.name}: ${v.node}`).join(', ')}
         }), [nodes])
@@ -444,19 +450,19 @@ export class GenerateR3F<O extends GenerateOptions = GenerateOptions> extends Ab
       export function ${componentName}(props: ${modelPropsName}) {
         ${
           hasInstances
-            ? 'const instances = React.useContext(context)'
+            ? `const instances = React.useContext(context)${hasAnimations ? `\n        const { animations } = useGLTF(modelLoadPath, draco) as unknown as ${modelGLTFName}` : ''}`
             : hasPrimitives
               ? `
-                const { ${hasAnimations ? 'animations, ' : ''}scene } = useGLTF(modelLoadPath, draco) as ${modelGLTFName}
+                const { ${hasAnimations ? 'animations, ' : ''}scene } = useGLTF(modelLoadPath, draco) as unknown as ${modelGLTFName}
                 const clone = React.useMemo(() => SkeletonUtils.clone(scene), [scene])
-                const { nodes, materials } = useGraph(clone) as ${modelGLTFName}
+                const { nodes, materials } = useGraph(clone) as unknown as ${modelGLTFName}
               `
-              : `const { ${hasAnimations ? 'animations, ' : ''}nodes, materials } = useGLTF(modelLoadPath, draco) as ${modelGLTFName}`
+              : `const { ${hasAnimations ? 'animations, ' : ''}nodes, materials } = useGLTF(modelLoadPath, draco) as unknown as ${modelGLTFName}`
         }
         ${
           hasAnimations
             ? `
-          const groupRef = React.useRef<Group>()
+          const groupRef = React.useRef<Group>(null)
           const { actions } = useAnimations(animations, groupRef)
           `
             : ''

--- a/test/generate/r3f/fiber-v9-compat.test.ts
+++ b/test/generate/r3f/fiber-v9-compat.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Regression tests for fiber v9 / drei v10 / React 19 compatibility in generated output.
+ *
+ * fiber v9 removed the per-element prop type aliases (GroupProps, MeshProps, etc.) as named exports.
+ * They are now accessed via ThreeElements['group'] / ThreeElements['mesh'].
+ * Additionally, useGLTF's return type in drei v10 is GLTF & ObjectMap, so casting to a narrower type
+ * requires `as unknown as XxxGLTF` (double cast) rather than a direct `as XxxGLTF`.
+ *
+ * The FlightHelmet fixture is a plain mesh model (no bones/lights/animations), so the primitives/skeleton
+ * and animations template branches are not produced by the standard fixtures. Those branches are forced
+ * here (subclass override for primitives; an injected AnimationClip for animations) so their cast sites and
+ * three imports are exercised, not just grep-verified.
+ */
+
+import { DRACOLoader, type GLTF } from 'node-three-gltf'
+import { AnimationClip } from 'three'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import {
+  AnalyzedGLTF,
+  type GenerateOptions,
+  GenerateR3F,
+  loadGLTF,
+  resolveModelLoadPath,
+} from '../../../src/index.ts'
+import {
+  assertFileExists,
+  fixtureAnalyzeOptions,
+  fixtureGenerateOptions,
+  resolveFixtureModelFile,
+} from '../../fixtures.ts'
+
+const modelName = 'FlightHelmet'
+
+// A single `as <Name>GLTF` cast that is NOT preceded by `as unknown` — i.e. the too-strict drei-v10 form.
+// Matches `) as FooGLTF` but not `) as unknown as FooGLTF`, so it flags a regression at any cast site
+// (useGLTF or useGraph), not only the ones a given fixture happens to emit.
+const singleGltfCast = /\)\s+as\s+(?!unknown\b)\w+GLTF/
+
+describe('fiber v9 compatibility', () => {
+  describe(modelName, () => {
+    const type = 'gltf'
+    const modelFile = resolveFixtureModelFile(modelName, type)
+
+    let model: GLTF
+    let options: GenerateOptions
+    let a: AnalyzedGLTF
+    let dracoLoader: DRACOLoader
+
+    beforeAll(async () => {
+      dracoLoader = new DRACOLoader()
+      assertFileExists(modelFile)
+      model = await loadGLTF(modelFile, dracoLoader)
+      options = fixtureGenerateOptions({
+        componentName: modelName,
+        draco: false,
+        keepnames: true,
+        modelLoadPath: resolveModelLoadPath(modelFile, '/public/models'),
+      })
+      a = new AnalyzedGLTF(model, fixtureAnalyzeOptions(options))
+    })
+
+    afterAll(() => {
+      dracoLoader.dispose()
+    })
+
+    describe('Breakage A — removed fiber type exports', () => {
+      // fiber v9 removed GroupProps, MeshProps (and the whole element-prop alias family) as named exports.
+      // The generator must import `type { ThreeElements }` instead and use ThreeElements['group'] /
+      // ThreeElements['mesh'] in the generated component.
+      it.concurrent('should not import GroupProps or MeshProps from @react-three/fiber', async () => {
+        const g = new GenerateR3F(a, options)
+        const tsx = await g.toTsx()
+
+        expect(tsx).not.toMatch(/import[^;]*GroupProps[^;]*from\s+['"]@react-three\/fiber['"]/)
+        expect(tsx).not.toMatch(/import[^;]*MeshProps[^;]*from\s+['"]@react-three\/fiber['"]/)
+      })
+
+      it.concurrent('should use ThreeElements to derive element prop types', async () => {
+        const g = new GenerateR3F(a, options)
+        const tsx = await g.toTsx()
+
+        expect(tsx).toContain('ThreeElements')
+        expect(tsx).toMatch(/ThreeElements\[['"]group['"]\]/)
+      })
+
+      it.concurrent('should use ThreeElements for ContextType in instanceall variant', async () => {
+        const instanceAllFile = resolveFixtureModelFile(
+          modelName,
+          'gltf-transform-draco-instanceall',
+        )
+        assertFileExists(instanceAllFile)
+        const instanceModel = await loadGLTF(instanceAllFile, dracoLoader)
+        const instanceOptions = fixtureGenerateOptions({
+          componentName: modelName,
+          draco: true,
+          instanceall: true,
+          keepnames: true,
+          modelLoadPath: resolveModelLoadPath(instanceAllFile, '/public/models'),
+        })
+        const ia = new AnalyzedGLTF(instanceModel, fixtureAnalyzeOptions(instanceOptions))
+        const g = new GenerateR3F(ia, instanceOptions)
+        const tsx = await g.toTsx()
+
+        expect(tsx).not.toMatch(/import[^;]*MeshProps[^;]*from\s+['"]@react-three\/fiber['"]/)
+        // ContextType record should use ThreeElements['mesh'] not MeshProps
+        expect(tsx).toMatch(/ThreeElements\[['"]mesh['"]\]/)
+      })
+    })
+
+    describe('Breakage B — useGLTF cast too strict', () => {
+      // drei v10 useGLTF returns GLTF & ObjectMap whose nodes/materials are index signatures of the
+      // base types (Object3D / Material). A direct `as XxxGLTF` cast fails TS2352 because neither
+      // type sufficiently overlaps with the other. The fix is `as unknown as XxxGLTF`.
+      it.concurrent('should cast useGLTF result with double cast (as unknown as)', async () => {
+        const g = new GenerateR3F(a, options)
+        const tsx = await g.toTsx()
+
+        expect(tsx).toMatch(/useGLTF\([^)]+\)\s+as\s+unknown\s+as\s+\w+GLTF/)
+        expect(tsx).not.toMatch(singleGltfCast)
+      })
+    })
+
+    describe('Primitives/skeleton path — useGraph + useGLTF casts', () => {
+      // FlightHelmet has no bones/lights, so the primitives branch (which adds the SkeletonUtils.clone +
+      // useGraph path) is never produced by the fixtures. Force it so both of its cast sites are exercised:
+      // a regression to a single cast at either useGLTF or useGraph would otherwise pass undetected.
+      class ForcedPrimitivesGenerateR3F extends GenerateR3F {
+        protected override hasPrimitives() {
+          return true
+        }
+      }
+
+      it.concurrent('should double-cast both useGLTF and useGraph', async () => {
+        const g = new ForcedPrimitivesGenerateR3F(a, options)
+        const tsx = await g.toTsx()
+
+        expect(tsx).toMatch(/useGLTF\([^)]+\)\s+as\s+unknown\s+as\s+\w+GLTF/)
+        expect(tsx).toMatch(/useGraph\([^)]+\)\s+as\s+unknown\s+as\s+\w+GLTF/)
+        expect(tsx).not.toMatch(singleGltfCast)
+      })
+
+      it.concurrent('should handle primitives + animations together', async () => {
+        const animModel = await loadGLTF(modelFile, dracoLoader)
+        animModel.animations.push(new AnimationClip('Idle', 1, []))
+        const animOptions = fixtureGenerateOptions({
+          componentName: modelName,
+          draco: false,
+          keepnames: true,
+          modelLoadPath: resolveModelLoadPath(modelFile, '/public/models'),
+        })
+        const animA = new AnalyzedGLTF(animModel, fixtureAnalyzeOptions(animOptions))
+        const g = new ForcedPrimitivesGenerateR3F(animA, animOptions)
+        const tsx = await g.toTsx()
+
+        // primitives branch destructures `animations, scene` from the single useGLTF, then useGraph for the rest
+        expect(tsx).toMatch(
+          /const\s*\{\s*animations,\s*scene\s*\}\s*=\s*useGLTF\([^)]+\)\s+as\s+unknown\s+as\s+\w+GLTF/,
+        )
+        expect(tsx).toMatch(/useGraph\([^)]+\)\s+as\s+unknown\s+as\s+\w+GLTF/)
+        expect(tsx).toMatch(/useAnimations\(animations,/)
+        expect(tsx).toMatch(/useRef<Group>\(null\)/)
+        expect(tsx).not.toMatch(singleGltfCast)
+      })
+    })
+
+    describe('Animations path — Group import + React 19 useRef', () => {
+      // The animations branch references Group and React.useRef<Group>(). Under named three imports Group
+      // must be imported (else TS2304), and React 19 removed the zero-arg useRef overload (else TS2554).
+      // FlightHelmet has no animations, so inject a clip to produce the branch.
+      it.concurrent('should import Group and call useRef<Group>(null)', async () => {
+        const animModel = await loadGLTF(modelFile, dracoLoader)
+        animModel.animations.push(new AnimationClip('Idle', 1, []))
+        const animOptions = fixtureGenerateOptions({
+          componentName: modelName,
+          draco: false,
+          keepnames: true,
+          modelLoadPath: resolveModelLoadPath(modelFile, '/public/models'),
+        })
+        const animA = new AnalyzedGLTF(animModel, fixtureAnalyzeOptions(animOptions))
+        const g = new GenerateR3F(animA, animOptions)
+        const tsx = await g.toTsx()
+
+        expect(tsx).toMatch(/import\s*\{[^}]*\bGroup\b[^}]*\}\s*from\s*['"]three['"]/)
+        expect(tsx).toMatch(/useRef<Group>\(null\)/)
+        // animations path still goes through the standard useGLTF cast site
+        expect(tsx).not.toMatch(singleGltfCast)
+      })
+    })
+
+    describe('Instanceall + animations path — animations must be declared', () => {
+      // The instances branch sources geometry from React.useContext(context), not useGLTF, so it does not
+      // destructure `animations`. With animations present, useAnimations(animations, ...) would reference an
+      // undeclared name (TS2304). The clips must come from the (suspense-cached) useGLTF in the same scope.
+      it.concurrent('should destructure animations from useGLTF in the instances branch', async () => {
+        const instanceAllFile = resolveFixtureModelFile(
+          modelName,
+          'gltf-transform-draco-instanceall',
+        )
+        assertFileExists(instanceAllFile)
+        const instanceModel = await loadGLTF(instanceAllFile, dracoLoader)
+        instanceModel.animations.push(new AnimationClip('Idle', 1, []))
+        const instanceOptions = fixtureGenerateOptions({
+          componentName: modelName,
+          draco: true,
+          instanceall: true,
+          keepnames: true,
+          modelLoadPath: resolveModelLoadPath(instanceAllFile, '/public/models'),
+        })
+        const ia = new AnalyzedGLTF(instanceModel, fixtureAnalyzeOptions(instanceOptions))
+        const g = new GenerateR3F(ia, instanceOptions)
+        const tsx = await g.toTsx()
+
+        expect(tsx).toMatch(
+          /const\s*\{\s*animations\s*\}\s*=\s*useGLTF\([^)]+\)\s+as\s+unknown\s+as\s+\w+GLTF/,
+        )
+        expect(tsx).toMatch(/useAnimations\(animations,/)
+        expect(tsx).not.toMatch(singleGltfCast)
+      })
+    })
+  })
+})


### PR DESCRIPTION
Closes #17.

`@rosskevin/gltfjsx` was emitting fiber-v8-shaped components that no longer type-check against `@react-three/fiber` 9 / `@react-three/drei` 10 / React 19 (surfaced while upgrading a consuming app).

## Fixes

- **fiber v9 type exports (TS2305):** import `{ type ThreeElements, useGraph }` instead of the removed `GroupProps`/`MeshProps`; derive props via `type XPropsBase = ThreeElements['group']` + `interface XProps extends XPropsBase {}` (an interface heritage clause cannot be an indexed-access type — TS2499), and use `ThreeElements['mesh']` for the instanceall `ContextType`.
- **drei v10 useGLTF cast (TS2352):** `useGLTF`/`useGraph` now return `GLTF & ObjectMap`, so cast `as unknown as XGLTF` at every site (standard, instanceall, primitives/skeleton).
- **animations branch (TS2304 / TS2554):** import `Group` (it was referenced unimported) and use `React.useRef<Group>(null)` (React 19 removed the zero-arg `useRef` overload).
- **instanceall + animations (TS2304):** source `animations` from the suspense-cached `useGLTF` — the `React.useContext(context)` branch never destructured it.

## Tests

Adds `test/generate/r3f/fiber-v9-compat.test.ts`. The only fixture (FlightHelmet) is a plain mesh, so the primitives/skeleton and animations branches are force-generated (subclass override + injected `AnimationClip`); every branch combination is exercised and each assertion was mutation-verified. `pnpm check` green (59 tests).

> This repo has no react/fiber/drei deps (it generates code, doesn't consume it), so tests assert the generated string rather than running `tsc` over emitted output — verified compiling in a consuming app (tsc 6, fiber 9.6, drei 10.7, three 0.184, Vite 8).

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>8.0.1--canary.18.55ce772.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @rosskevin/gltfjsx@8.0.1--canary.18.55ce772.0
  # or 
  yarn add @rosskevin/gltfjsx@8.0.1--canary.18.55ce772.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
